### PR TITLE
fix: handle case when a pool is added liquidity in full range (#4)

### DIFF
--- a/entities/pool.go
+++ b/entities/pool.go
@@ -251,14 +251,14 @@ func (p *Pool) swap(zeroForOne bool, amountSpecified, sqrtPriceLimitX96 *big.Int
 	}
 
 	if zeroForOne {
-		if sqrtPriceLimitX96.Cmp(utils.MinSqrtRatio) <= 0 {
+		if sqrtPriceLimitX96.Cmp(utils.MinSqrtRatio) < 0 {
 			return nil, nil, nil, nil, 0, ErrSqrtPriceLimitX96TooLow
 		}
 		if sqrtPriceLimitX96.Cmp(p.SqrtRatioX96) >= 0 {
 			return nil, nil, nil, nil, 0, ErrSqrtPriceLimitX96TooHigh
 		}
 	} else {
-		if sqrtPriceLimitX96.Cmp(utils.MaxSqrtRatio) >= 0 {
+		if sqrtPriceLimitX96.Cmp(utils.MaxSqrtRatio) > 0 {
 			return nil, nil, nil, nil, 0, ErrSqrtPriceLimitX96TooHigh
 		}
 		if sqrtPriceLimitX96.Cmp(p.SqrtRatioX96) <= 0 {


### PR DESCRIPTION
If the pool is added liquidity in full range (from min tick to max tick), it will push the sqrtPriceLimitX96 to the extreme case, thus cause the swap function to return nil all the time