### PR TITLE
refactor: avoid using panic (it crashes the API)

### DIFF
--- a/entities/tickdataprovider.go
+++ b/entities/tickdataprovider.go
@@ -14,7 +14,7 @@ type TickDataProvider interface {
 	 * Return information corresponding to a specific tick
 	 * @param tick the tick to load
 	 */
-	GetTick(tick int) Tick
+	GetTick(tick int) (Tick, error)
 
 	/**
 	 * Return the next tick that is initialized within a single word
@@ -22,7 +22,7 @@ type TickDataProvider interface {
 	 * @param lte Whether the next tick should be lte the current tick
 	 * @param tickSpacing The tick spacing of the pool
 	 */
-	NextInitializedTickWithinOneWord(tick int, lte bool, tickSpacing int) (int, bool)
+	NextInitializedTickWithinOneWord(tick int, lte bool, tickSpacing int) (int, bool, error)
 
 	/**
 	 * Return the next tick that is initialized within a fixed distance
@@ -30,5 +30,5 @@ type TickDataProvider interface {
 	 * @param lte Whether the next tick should be lte the current tick
 	 * @param distance The distance
 	 */
-	NextInitializedTickWithinFixedDistance(tick int, lte bool, distance int) (int, bool)
+	NextInitializedTickWithinFixedDistance(tick int, lte bool, distance int) (int, bool, error)
 }

--- a/entities/ticklist_test.go
+++ b/entities/ticklist_test.go
@@ -35,14 +35,21 @@ func TestValidateList(t *testing.T) {
 
 func TestIsBelowSmallest(t *testing.T) {
 	result := []Tick{lowTick, midTick, highTick}
-	assert.True(t, IsBelowSmallest(result, utils.MinTick))
-	assert.False(t, IsBelowSmallest(result, utils.MinTick+1))
+	isBelowSmallest1, _ := IsBelowSmallest(result, utils.MinTick)
+	assert.True(t, isBelowSmallest1)
+
+	isBelowSmallest2, _ := IsBelowSmallest(result, utils.MinTick+1)
+	assert.False(t, isBelowSmallest2)
 }
 
 func TestIsAtOrAboveSmallest(t *testing.T) {
 	result := []Tick{lowTick, midTick, highTick}
-	assert.False(t, IsAtOrAboveLargest(result, utils.MaxTick-2))
-	assert.True(t, IsAtOrAboveLargest(result, utils.MaxTick-1))
+
+	isAtOrAboveLargest1, _ := IsAtOrAboveLargest(result, utils.MaxTick-2)
+	assert.False(t, isAtOrAboveLargest1)
+
+	isAtOrAboveLargest2, _ := IsAtOrAboveLargest(result, utils.MaxTick-1)
+	assert.True(t, isAtOrAboveLargest2)
 }
 
 func TestNextInitializedTick(t *testing.T) {
@@ -74,12 +81,18 @@ func TestNextInitializedTick(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, NextInitializedTick(tt.args.ticks, tt.args.tick, tt.args.lte))
+			nextInitializedTick, _ := NextInitializedTick(tt.args.ticks, tt.args.tick, tt.args.lte)
+			assert.Equal(t, tt.want, nextInitializedTick)
 		})
 	}
 
-	assert.Panics(t, func() { NextInitializedTick(ticks, utils.MinTick, true) }, "blow smallest")
-	assert.Panics(t, func() { NextInitializedTick(ticks, utils.MaxTick-1, false) }, "at or above largest")
+	nextInitializedTick1, err1 := NextInitializedTick(ticks, utils.MinTick, true)
+	assert.Zero(t, nextInitializedTick1, "below smallest")
+	assert.ErrorIs(t, err1, ErrBelowSmallest)
+
+	nextInitializedTick2, err2 := NextInitializedTick(ticks, utils.MaxTick-1, false)
+	assert.Zero(t, nextInitializedTick2, "at or above largest")
+	assert.ErrorIs(t, err2, ErrAtOrAboveLargest)
 }
 
 func TestNextInitializedTickWithinOneWord(t *testing.T) {
@@ -123,7 +136,7 @@ func TestNextInitializedTickWithinOneWord(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got0, got1 := NextInitializedTickWithinOneWord(tt.args.ticks, tt.args.tick, tt.args.lte, tt.args.tickSpacing)
+			got0, got1, _ := NextInitializedTickWithinOneWord(tt.args.ticks, tt.args.tick, tt.args.lte, tt.args.tickSpacing)
 			assert.Equal(t, tt.want0, got0)
 			assert.Equal(t, tt.want1, got1)
 		})

--- a/entities/ticklistdataprovider.go
+++ b/entities/ticklistdataprovider.go
@@ -12,14 +12,14 @@ func NewTickListDataProvider(ticks []Tick, tickSpacing int) (*TickListDataProvid
 	return &TickListDataProvider{ticks: ticks}, nil
 }
 
-func (p *TickListDataProvider) GetTick(tick int) Tick {
+func (p *TickListDataProvider) GetTick(tick int) (Tick, error) {
 	return GetTick(p.ticks, tick)
 }
 
-func (p *TickListDataProvider) NextInitializedTickWithinOneWord(tick int, lte bool, tickSpacing int) (int, bool) {
+func (p *TickListDataProvider) NextInitializedTickWithinOneWord(tick int, lte bool, tickSpacing int) (int, bool, error) {
 	return NextInitializedTickWithinOneWord(p.ticks, tick, lte, tickSpacing)
 }
 
-func (p *TickListDataProvider) NextInitializedTickWithinFixedDistance(tick int, lte bool, distance int) (int, bool) {
+func (p *TickListDataProvider) NextInitializedTickWithinFixedDistance(tick int, lte bool, distance int) (int, bool, error) {
 	return NextInitializedTickWithinFixedDistance(p.ticks, tick, lte, distance)
 }


### PR DESCRIPTION
When a proxy has a problem, or for some reason, the `ticks` data will be broken, and if we use `panic` inside the SDK, it causes the API to be crashed => no route is found

For example:
```
err: Post "https://api.thegraph.com/subgraphs/name/kybernetwork/kyberswap-elastic-matic": Proxy Manager - Bad Gateway
63
[2022-09-02T02:14:47Z] ERROR kyberswapv2: failed to query subgraph for pool ticks, err: Post "https://api.thegraph.com/subgraphs/name/kybernetwork/kyberswap-elastic-matic": Proxy Manager - Bad Gateway
62
[2022-09-02T02:14:47Z]  INFO kyberswap-static: update reserves 0 pairs in 1.700050404s
61
[2022-09-02T02:14:47Z] ERROR kyberswapv2: failed to query subgraph, err: Post "https://api.thegraph.com/subgraphs/name/kybernetwork/kyberswap-elastic-matic": Proxy Manager - Bad Gateway
60
[2022-09-02T02:14:47Z] ERROR kyberswapv2: failed to query subgraph for pool ticks, err: Post "https://api.thegraph.com/subgraphs/name/kybernetwork/kyberswap-elastic-matic": Proxy Manager - Bad Gateway
59
[2022-09-02T02:14:47Z]  INFO gravity: update reserves 71 pairs in 1.546811671s
58
[2022-09-02T02:14:47Z]  INFO kyberswap: update reserves 47 pairs in 1.564941898s
```

So we have to refactor the code to return the error